### PR TITLE
Solved compilation issue with ubuntu 16

### DIFF
--- a/packages/ros2-test/CMakeLists.txt
+++ b/packages/ros2-test/CMakeLists.txt
@@ -13,6 +13,12 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(test_msgs REQUIRED)
 
+if(NOT CMAKE_CXX_STANDARD)
+  # TODO(MXG): Remove this block and use target_compile_features(~)
+  # instead when we no longer need to support Ubuntu 16.04.
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 soss_rosidl_mix(
   PACKAGES geometry_msgs nav_msgs test_msgs
   MIDDLEWARES ros2


### PR DESCRIPTION
Hi, this PR solves an issue found compiling in ubuntu 16.

Ubuntu 16 comes with g++ compiler version 5, does not support cxx14 by default. This not appears to be a problem because the CMakeLists of the packages set this flag. Nevertheless, *soss-ros2-test* calls to a cmake macro called `soss_rosidl_mix` that seems to compile files avoiding this cxx14 configuration.

I added the flag for cxx14 before this macro with the same *style* that I found in other packages.