### PR TITLE
Support dispatch templates for topic names

### DIFF
--- a/packages/core/CMakeLists.txt
+++ b/packages/core/CMakeLists.txt
@@ -29,12 +29,13 @@ find_package(Boost REQUIRED
 # Configure soss-core library
 add_library(soss-core SHARED
   src/Config.cpp
+  src/FieldToString.cpp
   src/Instance.cpp
   src/Message.cpp
   src/MiddlewareInterfaceExtension.cpp
   src/register_system.cpp
   src/Search.cpp
-  src/FieldToString.cpp
+  src/StringTemplate.cpp
 )
 
 target_link_libraries(soss-core

--- a/packages/core/CMakeLists.txt
+++ b/packages/core/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(soss-core SHARED
   src/MiddlewareInterfaceExtension.cpp
   src/register_system.cpp
   src/Search.cpp
+  src/FieldToString.cpp
 )
 
 target_link_libraries(soss-core

--- a/packages/core/include/soss/FieldToString.hpp
+++ b/packages/core/include/soss/FieldToString.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SOSS__FIELDTOSTRING_HPP
+#define SOSS__FIELDTOSTRING_HPP
+
+#include <soss/Message.hpp>
+
+namespace soss {
+
+//==============================================================================
+/// \brief Convenience class for converting simple field types into strings.
+class FieldToString
+{
+public:
+
+  /// Construct this and set the details for how the conversion is being used.
+  FieldToString(const std::string& usage_details);
+
+  /// Convert a field to a string.
+  std::string to_string(const soss::Message::const_iterator& field_it) const;
+
+  /// If an unknown conversion is requested, this string will get passed along
+  /// to the UnknownFieldToStringCast exception that gets thrown.
+  ///
+  /// Ideally this string should contain information like:
+  /// 1. What middleware is using the conversion?
+  /// 2. What message+topic pair is using the conversion?
+  std::string details;
+
+};
+
+//==============================================================================
+/// \brief Exception that gets thrown by FieldToString when it's unknown how to
+/// convert a given field type into a string.
+class UnknownFieldToStringCast : public std::runtime_error
+{
+public:
+
+  UnknownFieldToStringCast(
+      const std::string& type_info,
+      const std::string& field_name,
+      const std::string& details);
+
+  const std::string& type() const;
+
+  const std::string& field_name() const;
+
+private:
+
+  const std::string _type;
+  const std::string _field_name;
+
+};
+
+} // namespace soss
+
+#endif // SOSS__FIELDTOSTRING_HPP

--- a/packages/core/include/soss/Message.hpp
+++ b/packages/core/include/soss/Message.hpp
@@ -103,10 +103,14 @@ public:
   /// The string that uniquely defines this message type
   std::string type;
 
+  using FieldMap = std::map<std::string, Field>;
+  using iterator = FieldMap::iterator;
+  using const_iterator = FieldMap::const_iterator;
+
   /// The data that this message contains. This will point to a middleware
   /// neutral type defined in a soss library. Each middleware will have its own
   /// functions for converting to/from this type.
-  std::map<std::string, Field> data;
+  FieldMap data;
 
 };
 

--- a/packages/core/include/soss/StringTemplate.hpp
+++ b/packages/core/include/soss/StringTemplate.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SOSS__STRINGTEMPLATE_HPP
+#define SOSS__STRINGTEMPLATE_HPP
+
+#include <soss/Message.hpp>
+
+namespace soss {
+
+//==============================================================================
+class StringTemplate
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] template_string
+  ///   A string that describes the desired template. Varying components of the
+  ///   string must be wrapped in curly braces {}. Currently only
+  ///   {message.<field>} variables are supported. Those components of the
+  ///   string will be replaced by the value of the requested field when
+  ///   compute_string() is called.
+  ///
+  /// \param[in] usage_details
+  ///   A string that describes how this StringTemplate is being used. Ideally
+  ///   this should contain information like:
+  ///   1. What middleware is using the template?
+  ///   2. What message+topic pair is using the conversion?
+  StringTemplate(
+      const std::string& template_string,
+      const std::string& usage_details);
+
+  /// Compute the desired output string given the input message.
+  std::string compute_string(const soss::Message& message) const;
+
+  /// Mutable reference to the usage details for this StringTemplate
+  std::string& usage_details();
+
+  /// Const reference to the usage details for this StringTemplate
+  const std::string& usage_details() const;
+
+private:
+
+  class Implementation;
+  std::unique_ptr<Implementation> pimpl;
+
+};
+
+//==============================================================================
+class InvalidTemplateFormat : public std::runtime_error
+{
+public:
+
+  InvalidTemplateFormat(
+      const std::string& template_string,
+      const std::string& details);
+
+  const std::string& template_string() const;
+
+private:
+
+  const std::string _template_string;
+
+};
+
+//==============================================================================
+class UnavailableMessageField : public std::runtime_error
+{
+public:
+
+  UnavailableMessageField(
+      const std::string& field_name,
+      const std::string& details);
+
+  const std::string& field_name() const;
+
+private:
+
+  const std::string _field_name;
+
+};
+
+} // namespace soss
+
+#endif // SOSS__STRINGTEMPLATE_HPP

--- a/packages/core/include/soss/StringTemplate.hpp
+++ b/packages/core/include/soss/StringTemplate.hpp
@@ -45,6 +45,9 @@ public:
       const std::string& template_string,
       const std::string& usage_details);
 
+  StringTemplate(const StringTemplate& other);
+  StringTemplate(StringTemplate&& other);
+
   /// Compute the desired output string given the input message.
   std::string compute_string(const soss::Message& message) const;
 
@@ -53,6 +56,9 @@ public:
 
   /// Const reference to the usage details for this StringTemplate
   const std::string& usage_details() const;
+
+  // Destructor
+  ~StringTemplate();
 
 private:
 

--- a/packages/core/src/FieldToString.cpp
+++ b/packages/core/src/FieldToString.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <soss/FieldToString.hpp>
+
+#include <string>
+#include <unordered_map>
+
+namespace soss {
+
+namespace {
+//==============================================================================
+class FieldConversions
+{
+public:
+
+  static const FieldConversions& instance()
+  {
+    static FieldConversions conversions;
+    return conversions;
+  }
+
+  std::string to_string(
+      const soss::Message::const_iterator& field_it,
+      const std::string& details) const
+  {
+    const auto& field_name = field_it->first;
+    const auto& field = field_it->second;
+
+    const std::string& type = field.type();
+    const auto it = conversions.find(type);
+    if(it != conversions.end())
+      return it->second(field);
+
+    throw UnknownFieldToStringCast(type, field_name, details);
+  }
+
+private:
+
+  FieldConversions()
+  {
+    conversions[typeid(std::string).name()] = [](const soss::Field& field)
+    {
+      return *field.cast<std::string>();
+    };
+
+    add_primitive_conversion<int64_t>();
+    add_primitive_conversion<uint64_t>();
+    add_primitive_conversion<double>();
+  }
+
+  template<typename T>
+  void add_primitive_conversion()
+  {
+    conversions[typeid(T).name()] = [](const soss::Field& field)
+    {
+      return std::to_string(*field.cast<T>());
+    };
+  }
+
+  using ConversionFunc = std::function<std::string(const soss::Field&)>;
+  using ConversionMap = std::unordered_map<std::string, ConversionFunc>;
+
+  ConversionMap conversions;
+};
+} // anonymous namespace
+
+//==============================================================================
+FieldToString::FieldToString(const std::string& usage_details)
+  : details(usage_details)
+{
+  // Do nothing
+}
+
+//==============================================================================
+std::string FieldToString::to_string(
+    const Message::const_iterator& field_it) const
+{
+  return FieldConversions::instance().to_string(field_it, details);
+}
+
+//==============================================================================
+UnknownFieldToStringCast::UnknownFieldToStringCast(
+    const std::string& type,
+    const std::string& field_name,
+    const std::string& details)
+  : std::runtime_error(
+      std::string()
+      + "ERROR: Unable to cast type [" + type + "] of field [" + field_name
+      + "] to a string. Details: " + details),
+    _type(type),
+    _field_name(field_name)
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& UnknownFieldToStringCast::type() const
+{
+  return _type;
+}
+
+//==============================================================================
+const std::string& UnknownFieldToStringCast::field_name() const
+{
+  return _field_name;
+}
+
+} // namespace soss

--- a/packages/core/src/StringTemplate.cpp
+++ b/packages/core/src/StringTemplate.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <soss/StringTemplate.hpp>
+#include <soss/FieldToString.hpp>
+
+namespace soss {
+
+//==============================================================================
+class StringTemplate::Implementation
+{
+public:
+
+  Implementation(
+      const std::string& template_string,
+      const std::string& usage_details)
+    : converter(usage_details)
+  {
+    std::size_t last_start = 0;
+    std::size_t start = template_string.find('{', 0);
+    while(start < template_string.size())
+    {
+      components.push_back(template_string.substr(last_start, start));
+
+      const std::size_t end = template_string.find('}', start);
+      if(end == std::string::npos)
+      {
+        throw InvalidTemplateFormat(template_string, usage_details);
+      }
+
+      substitutions[components.size()] = template_string.substr(start+1, end);
+      // We use an empty string to represent components that will get
+      // substituted later.
+      components.push_back("");
+
+      last_start = start;
+      start = template_string.find('{', start);
+    }
+  }
+
+  std::string compute_string(const soss::Message& message) const
+  {
+    std::string result;
+
+    SubstitutionMap::const_iterator substitute_it = substitutions.begin();
+    for(std::size_t i=0; i < components.size(); ++i)
+    {
+      if(substitute_it != substitutions.end() && substitute_it->first == i)
+      {
+        const std::string& field_name = substitute_it->second;
+        const soss::Message::const_iterator field_it =
+            message.data.find(field_name);
+
+        if(field_it == message.data.end())
+        {
+          throw UnavailableMessageField(field_name, converter.details);
+        }
+
+        result += converter.to_string(field_it);
+        ++substitute_it;
+        continue;
+      }
+
+      result += components[i];
+    }
+
+    return result;
+  }
+
+  FieldToString converter;
+
+  /// This contains a vector of string literal components.
+  std::vector<std::string> components;
+
+  // This uses an ordered map so that we can iterate through it linearly as we
+  // perform substitutions.
+  using SubstitutionMap = std::map<std::size_t, std::string>;
+
+  /// Right now this simply maps a component index to a soss::Message field name.
+  /// In the future, we can replace std::string with an abstract Substitution
+  /// class that gets factory generated based on what type of substitution is
+  /// requested. For right now we've only implemented "message.field"
+  /// substitutions.
+  SubstitutionMap substitutions;
+
+};
+
+//==============================================================================
+StringTemplate::StringTemplate(
+    const std::string& template_string,
+    const std::string& usage_details)
+  : pimpl(new Implementation(template_string, usage_details))
+{
+  // Do nothing
+}
+
+//==============================================================================
+std::string StringTemplate::compute_string(const soss::Message& message) const
+{
+  return pimpl->compute_string(message);
+}
+
+//==============================================================================
+std::string& StringTemplate::usage_details()
+{
+  return pimpl->converter.details;
+}
+
+//==============================================================================
+const std::string& StringTemplate::usage_details() const
+{
+  return pimpl->converter.details;
+}
+
+//==============================================================================
+InvalidTemplateFormat::InvalidTemplateFormat(
+    const std::string& template_string,
+    const std::string& details)
+  : std::runtime_error(
+      std::string()
+      + "ERROR: Template string [" + template_string + "] was incorrectly "
+      + "formatted. Details: " + details),
+    _template_string(template_string)
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& InvalidTemplateFormat::template_string() const
+{
+  return _template_string;
+}
+
+//==============================================================================
+UnavailableMessageField::UnavailableMessageField(
+    const std::string& field_name,
+    const std::string& details)
+  : std::runtime_error(
+      std::string()
+      + "ERROR: Unable to find a required field [" + field_name
+      + "]. Details: " + details),
+    _field_name(field_name)
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& UnavailableMessageField::field_name() const
+{
+  return _field_name;
+}
+
+} // namespace soss

--- a/packages/core/src/StringTemplate.cpp
+++ b/packages/core/src/StringTemplate.cpp
@@ -109,6 +109,20 @@ StringTemplate::StringTemplate(
 }
 
 //==============================================================================
+StringTemplate::StringTemplate(const StringTemplate& other)
+  : pimpl(new Implementation(*other.pimpl))
+{
+  // Do nothing
+}
+
+//==============================================================================
+StringTemplate::StringTemplate(StringTemplate&& other)
+  : pimpl(new Implementation(std::move(*other.pimpl)))
+{
+  // Do nothing
+}
+
+//==============================================================================
 std::string StringTemplate::compute_string(const soss::Message& message) const
 {
   return pimpl->compute_string(message);
@@ -124,6 +138,12 @@ std::string& StringTemplate::usage_details()
 const std::string& StringTemplate::usage_details() const
 {
   return pimpl->converter.details;
+}
+
+//==============================================================================
+StringTemplate::~StringTemplate()
+{
+  // Do nothing
 }
 
 //==============================================================================

--- a/packages/ros2/CMakeLists.txt
+++ b/packages/ros2/CMakeLists.txt
@@ -31,6 +31,7 @@ message(STATUS "Configuring [soss-ros2]")
 add_library(soss-ros2 SHARED
   src/Factory.cpp
   src/SystemHandle.cpp
+  src/MetaPublisher.cpp
 )
 
 target_link_libraries(soss-ros2

--- a/packages/ros2/src/MetaPublisher.cpp
+++ b/packages/ros2/src/MetaPublisher.cpp
@@ -43,7 +43,7 @@ public:
     // Do nothing
   }
 
-  bool publish(const soss::Message& message) override
+  bool publish(const soss::Message& message) override final
   {
     const std::string topic_name = _topic_template.compute_string(message);
 

--- a/packages/ros2/src/MetaPublisher.cpp
+++ b/packages/ros2/src/MetaPublisher.cpp
@@ -30,27 +30,44 @@ class MetaPublisher : public soss::TopicPublisher
 public:
 
   MetaPublisher(
-      TopicTemplate&& topic_template,
+      StringTemplate&& topic_template,
       const std::string& message_type,
-      const YAML::Node& configuration)
+      rclcpp::Node& node,
+      const rmw_qos_profile_t& qos_profile,
+      const YAML::Node& /*unused*/)
     : _topic_template(std::move(topic_template)),
       _message_type(message_type),
-      _configuration(configuration)
+      _node(node),
+      _qos_profile(qos_profile)
   {
     // Do nothing
   }
 
   bool publish(const soss::Message& message) override
   {
+    const std::string topic_name = _topic_template.compute_string(message);
 
+    const auto insertion = _publishers.insert(
+          std::make_pair(std::move(topic_name), nullptr));
+    const bool inserted = insertion.second;
+    TopicPublisherPtr& publisher = insertion.first->second;
+
+    if(inserted)
+    {
+      publisher = Factory::instance().create_publisher(
+            _message_type, _node, topic_name, _qos_profile);
+    }
+
+    return publisher->publish(message);
   }
 
 
 private:
 
-  const TopicTemplate _topic_template;
+  const soss::StringTemplate _topic_template;
   const std::string _message_type;
-  const YAML::Node _configuration;
+  rclcpp::Node& _node;
+  const rmw_qos_profile_t _qos_profile;
 
   using TopicPublisherPtr = std::shared_ptr<TopicPublisher>;
   using PublisherMap = std::unordered_map<std::string, TopicPublisherPtr>;
@@ -58,7 +75,30 @@ private:
 
 };
 
+namespace {
+//==============================================================================
+std::string make_detail_string(
+    const std::string& topic_name,
+    const std::string& message_type)
+{
+  return
+      "[Middleware: ROS2, topic template: "
+      + topic_name + ", message type: " + message_type + "]";
+}
+} // anonymous namespace
 
+//==============================================================================
+std::shared_ptr<soss::TopicPublisher> make_meta_publisher(
+    const std::string& message_type,
+    rclcpp::Node& node,
+    const std::string& topic_name,
+    const rmw_qos_profile_t& qos_profile,
+    const YAML::Node& configuration)
+{
+  return std::make_shared<MetaPublisher>(
+      StringTemplate(topic_name, make_detail_string(topic_name, message_type)),
+      message_type, node, qos_profile, configuration);
+}
 
 } // namespace ros2
 } // namespace soss

--- a/packages/ros2/src/MetaPublisher.cpp
+++ b/packages/ros2/src/MetaPublisher.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "MetaPublisher.hpp"
+
+#include <soss/ros2/Factory.hpp>
+
+#include <soss/StringTemplate.hpp>
+
+namespace soss {
+namespace ros2 {
+
+//==============================================================================
+class MetaPublisher : public soss::TopicPublisher
+{
+public:
+
+  MetaPublisher(
+      TopicTemplate&& topic_template,
+      const std::string& message_type,
+      const YAML::Node& configuration)
+    : _topic_template(std::move(topic_template)),
+      _message_type(message_type),
+      _configuration(configuration)
+  {
+    // Do nothing
+  }
+
+  bool publish(const soss::Message& message) override
+  {
+
+  }
+
+
+private:
+
+  const TopicTemplate _topic_template;
+  const std::string _message_type;
+  const YAML::Node _configuration;
+
+  using TopicPublisherPtr = std::shared_ptr<TopicPublisher>;
+  using PublisherMap = std::unordered_map<std::string, TopicPublisherPtr>;
+  PublisherMap _publishers;
+
+};
+
+
+
+} // namespace ros2
+} // namespace soss

--- a/packages/ros2/src/MetaPublisher.hpp
+++ b/packages/ros2/src/MetaPublisher.hpp
@@ -25,6 +25,7 @@
 namespace soss {
 namespace ros2 {
 
+//==============================================================================
 std::shared_ptr<TopicPublisher> make_meta_publisher(
     const std::string& message_type,
     rclcpp::Node& node,

--- a/packages/ros2/src/MetaPublisher.hpp
+++ b/packages/ros2/src/MetaPublisher.hpp
@@ -20,12 +20,16 @@
 
 #include <soss/SystemHandle.hpp>
 
+#include <rclcpp/node.hpp>
+
 namespace soss {
 namespace ros2 {
 
 std::shared_ptr<TopicPublisher> make_meta_publisher(
-    const std::string& topic_name,
     const std::string& message_type,
+    rclcpp::Node& node,
+    const std::string& topic_name,
+    const rmw_qos_profile_t& qos_profile,
     const YAML::Node& configuration);
 
 } // namespace ros2

--- a/packages/ros2/src/MetaPublisher.hpp
+++ b/packages/ros2/src/MetaPublisher.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SOSS__ROS2__SRC__METAPUBLISHER_HPP
+#define SOSS__ROS2__SRC__METAPUBLISHER_HPP
+
+#include <soss/SystemHandle.hpp>
+
+namespace soss {
+namespace ros2 {
+
+std::shared_ptr<TopicPublisher> make_meta_publisher(
+    const std::string& topic_name,
+    const std::string& message_type,
+    const YAML::Node& configuration);
+
+} // namespace ros2
+} // namespace soss
+
+#endif // SOSS__ROS2__SRC__METAPUBLISHER_HPP

--- a/packages/ros2/src/SystemHandle.cpp
+++ b/packages/ros2/src/SystemHandle.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "SystemHandle.hpp"
+#include "MetaPublisher.hpp"
 
 #include <soss/ros2/Factory.hpp>
 
@@ -219,6 +220,9 @@ std::shared_ptr<TopicPublisher> SystemHandle::advertise(
     const std::string& message_type,
     const YAML::Node& configuration)
 {
+  if(topic_name.find('{') != std::string::npos)
+    return make_meta_publisher(topic_name, message_type, configuration);
+
   return Factory::instance().create_publisher(
         message_type, *_node, topic_name,
         parse_rmw_qos_configuration(configuration));

--- a/packages/ros2/src/SystemHandle.cpp
+++ b/packages/ros2/src/SystemHandle.cpp
@@ -221,7 +221,14 @@ std::shared_ptr<TopicPublisher> SystemHandle::advertise(
     const YAML::Node& configuration)
 {
   if(topic_name.find('{') != std::string::npos)
-    return make_meta_publisher(topic_name, message_type, configuration);
+  {
+    // If the topic name contains a curly brace, we must assume that it needs
+    // runtime substitutions.
+    return make_meta_publisher(
+          message_type, *_node, topic_name,
+          parse_rmw_qos_configuration(configuration),
+          configuration);
+  }
 
   return Factory::instance().create_publisher(
         message_type, *_node, topic_name,


### PR DESCRIPTION
This allows a "dispatch template" to be specified in soss config files (for whichever middlewares are willing/able to support it), where topics can be dynamically remapped based on incoming message data.

So far it's implemented in `soss-ros2` and `soss-ros1` (the latter in a different repo).