### PR TITLE
Fix template substitution for string templates that have an ending substring

### DIFF
--- a/packages/core/src/StringTemplate.cpp
+++ b/packages/core/src/StringTemplate.cpp
@@ -57,6 +57,9 @@ public:
 
       start = template_string.find('{', last_end);
     }
+
+    if(last_end < template_string.size())
+      components.push_back(template_string.substr(last_end));
   }
 
   std::string compute_string(const soss::Message& message) const

--- a/packages/websocket-test/integration/websocket__dispatch.cpp
+++ b/packages/websocket-test/integration/websocket__dispatch.cpp
@@ -27,13 +27,18 @@ namespace {
 void run_test_case(
     const std::string& initial_topic,
     const std::string& name,
-    const uint32_t number)
+    const uint32_t number,
+    const std::string& suffix)
 {
+  const std::string topic =
+      initial_topic + "/" + name + "_" + std::to_string(number) + suffix;
+
+  std::cout << "Testing topic [" << topic << "]" << std::endl;
+
   std::promise<soss::Message> message_promise;
   auto message_future = message_promise.get_future();
   REQUIRE(soss::mock::subscribe(
-            initial_topic + "/" + name + "_" + std::to_string(number),
-            [&](const soss::Message& incoming_message)
+          topic, [&](const soss::Message& incoming_message)
   {
     message_promise.set_value(incoming_message);
   }));
@@ -75,13 +80,13 @@ TEST_CASE("Transmit and dispatch messages", "[websocket]")
   std::this_thread::sleep_for(5s);
   std::cout << " -- Done waiting!" << std::endl;
 
-  run_test_case("dispatch_into_client", "apple", 1);
-  run_test_case("dispatch_into_client", "banana", 2);
-  run_test_case("dispatch_into_client", "cherry", 3);
+  run_test_case("dispatch_into_client", "apple", 1, "/topic");
+  run_test_case("dispatch_into_client", "banana", 2, "/topic");
+  run_test_case("dispatch_into_client", "cherry", 3, "/topic");
 
-  run_test_case("dispatch_into_server", "avocado", 10);
-  run_test_case("dispatch_into_server", "blueberry", 20);
-  run_test_case("dispatch_into_server", "citrus", 30);
+  run_test_case("dispatch_into_server", "avocado", 10, "");
+  run_test_case("dispatch_into_server", "blueberry", 20, "");
+  run_test_case("dispatch_into_server", "citrus", 30, "");
 
   CHECK(handle.quit().wait() == 0);
 

--- a/packages/websocket-test/resources/websocket__dispatch.yaml
+++ b/packages/websocket-test/resources/websocket__dispatch.yaml
@@ -22,17 +22,17 @@ topics:
   dispatch_into_client:
     type: "websocket_test/Dispatch"
     route: mock_to_client
-    remap: { ws_client: "dispatch_into_client/{message.name}_{message.number}" }
+    remap: { ws_client: "dispatch_into_client/{message.name}_{message.number}/topic" }
 
-  "dispatch_into_client/apple_1":
+  "dispatch_into_client/apple_1/topic":
     type: "websocket_test/Dispatch"
     route: server_to_mock
 
-  "dispatch_into_client/banana_2":
+  "dispatch_into_client/banana_2/topic":
     type: "websocket_test/Dispatch"
     route: server_to_mock
 
-  "dispatch_into_client/cherry_3":
+  "dispatch_into_client/cherry_3/topic":
     type: "websocket_test/Dispatch"
     route: server_to_mock
 


### PR DESCRIPTION
This edge case was missed in the previous PRs, but now there are explicit tests for it.