### PR TITLE
Have cmake fail hard when dependencies are missing

### DIFF
--- a/packages/ros2/CMakeLists.txt
+++ b/packages/ros2/CMakeLists.txt
@@ -4,6 +4,7 @@ project(soss-ros2)
 
 find_package(soss-core REQUIRED)
 find_package(soss-rosidl REQUIRED)
+find_package(rclcpp REQUIRED)
 
 if(NOT CMAKE_CXX_STANDARD)
   # TODO(MXG): Remove this block and use target_compile_features(~)
@@ -16,15 +17,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 include(GNUInstallDirs)
-
-find_package(rclcpp QUIET)
-
-if(NOT rclcpp_FOUND)
-
-  message("Could not find package [rclcpp] -- we will skip configuring [soss-ros2]")
-  return()
-
-endif()
 
 message(STATUS "Configuring [soss-ros2]")
 

--- a/packages/websocket/CMakeLists.txt
+++ b/packages/websocket/CMakeLists.txt
@@ -8,6 +8,9 @@ endif()
 
 find_package(soss-core REQUIRED)
 find_package(soss-json REQUIRED)
+find_package(websocketpp REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
 if(NOT CMAKE_CXX_STANDARD)
   # TODO(MXG): Remove this block and use target_compile_features(~)
@@ -20,18 +23,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 include(GNUInstallDirs)
-
-find_package(websocketpp QUIET)
-
-if(NOT WEBSOCKETPP_FOUND)
-
-  message("Could not find package [websocketpp] -- we will skip configuring [soss-websocket]")
-  return()
-
-endif()
-
-find_package(OpenSSL REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system)
 
 message(STATUS "Configuring [soss-websocket]")
 


### PR DESCRIPTION
When I initially set up the build system, I thought it would be "nice" for the individual packages to be flexible about how they get configured so that it's easy for users to skip packages that they're missing dependencies for.

However, I've found that this causes more problems than it helps with, because if these packages quit with success when a dependency is missing, then it won't try to configure again after the user has installed the dependency.

The changes in this PR make the build system of each package quit with failure when one of its dependencies is missing. We'll just leave it up the user to explicitly select the packages they want (using `colcon build --packages-[select|up-to]`) if they only intend to install a subset of the soss plugins.