### PR TITLE
Support both Crystal and Dashing

### DIFF
--- a/packages/core/include/soss/utilities.hpp
+++ b/packages/core/include/soss/utilities.hpp
@@ -156,7 +156,8 @@ struct Convert
 
   static constexpr bool type_is_primitive =
          std::is_arithmetic<Type>::value
-      || std::is_same<std::string, Type>::value;
+      || std::is_same<std::string, Type>::value
+      || std::is_same<std::wstring, Type>::value;
 
   /// \brief Create an instance of the generic soss version of this type
   ///
@@ -246,7 +247,8 @@ struct LowPrecisionConvert
 
   static constexpr bool type_is_primitive =
          std::is_arithmetic<HighPrecision>::value
-      || std::is_same<std::string, HighPrecision>::value;
+      || std::is_same<std::string, HighPrecision>::value
+      || std::is_same<std::wstring, HighPrecision>::value;
 
   // Documentation inherited from Convert
   template<typename... Args>

--- a/packages/core/include/soss/utilities.hpp
+++ b/packages/core/include/soss/utilities.hpp
@@ -157,7 +157,7 @@ struct Convert
   static constexpr bool type_is_primitive =
          std::is_arithmetic<Type>::value
       || std::is_same<std::string, Type>::value
-      || std::is_same<std::wstring, Type>::value;
+      || std::is_same<std::basic_string<char16_t>, Type>::value;
 
   /// \brief Create an instance of the generic soss version of this type
   ///
@@ -248,7 +248,7 @@ struct LowPrecisionConvert
   static constexpr bool type_is_primitive =
          std::is_arithmetic<HighPrecision>::value
       || std::is_same<std::string, HighPrecision>::value
-      || std::is_same<std::wstring, HighPrecision>::value;
+      || std::is_same<std::basic_string<char16_t>, HighPrecision>::value;
 
   // Documentation inherited from Convert
   template<typename... Args>

--- a/packages/ros2-test/integration/ros2__geometry_msgs.cpp
+++ b/packages/ros2-test/integration/ros2__geometry_msgs.cpp
@@ -179,7 +179,7 @@ TEST_CASE("Talk between ros2 and the mock middleware", "[ros2]")
 #else
     const auto publisher =
         ros2->create_publisher<geometry_msgs::msg::Pose>(
-          "transmit_pose", rclcpp::SystemDefaultQoS());
+          "transmit_pose", rclcpp::SystemDefaultsQoS());
 #endif // RCLCPP__QOS_HPP_
     REQUIRE(publisher);
 
@@ -264,7 +264,7 @@ TEST_CASE("Talk between ros2 and the mock middleware", "[ros2]")
           "echo_pose", echo_sub);
 #else
     const auto subscriber = ros2->create_subscription<geometry_msgs::msg::Pose>(
-          "echo_pose", rclcpp::SystemDefaultQoS(), echo_sub);
+          "echo_pose", rclcpp::SystemDefaultsQoS(), echo_sub);
 #endif // RCLCPP__QOS_HPP_
 
     // Keep spinning and publishing while we wait for the promise to be

--- a/packages/ros2-test/integration/ros2__geometry_msgs.cpp
+++ b/packages/ros2-test/integration/ros2__geometry_msgs.cpp
@@ -173,8 +173,14 @@ TEST_CASE("Talk between ros2 and the mock middleware", "[ros2]")
 
   SECTION("Publish a pose and get it echoed back")
   {
+#ifndef RCLCPP__QOS_HPP_
     const auto publisher =
         ros2->create_publisher<geometry_msgs::msg::Pose>("transmit_pose");
+#else
+    const auto publisher =
+        ros2->create_publisher<geometry_msgs::msg::Pose>(
+          "transmit_pose", rclcpp::SystemDefaultQoS());
+#endif // RCLCPP__QOS_HPP_
     REQUIRE(publisher);
 
     std::promise<soss::Message> msg_promise;
@@ -253,8 +259,13 @@ TEST_CASE("Talk between ros2 and the mock middleware", "[ros2]")
       pose_promise.set_value(*msg);
     };
 
+#ifndef RCLCPP__QOS_HPP_
     const auto subscriber = ros2->create_subscription<geometry_msgs::msg::Pose>(
           "echo_pose", echo_sub);
+#else
+    const auto subscriber = ros2->create_subscription<geometry_msgs::msg::Pose>(
+          "echo_pose", rclcpp::SystemDefaultQoS(), echo_sub);
+#endif // RCLCPP__QOS_HPP_
 
     // Keep spinning and publishing while we wait for the promise to be
     // delivered. Try to cycle this for no more than a few seconds. If it's not

--- a/packages/ros2-test/integration/ros2__test_msgs.cpp
+++ b/packages/ros2-test/integration/ros2__test_msgs.cpp
@@ -16,6 +16,11 @@
 */
 
 #include <rclcpp/node.hpp>
+
+#ifdef RCLCPP__QOS_HPP_
+// This test currently does not work in the Dashing release. We will try to
+// resume comprehensive support for Dashing with xtypes in SOSSv3
+#else
 #include <rclcpp/executors/single_threaded_executor.hpp>
 
 #include <soss/mock/api.hpp>
@@ -263,3 +268,4 @@ TEST_CASE("Transmit and receive all test messages", "[ros2]")
   REQUIRE(!handle.running());
   REQUIRE(handle.wait() == 0);
 }
+#endif // RCLCPP__QOS_HPP_

--- a/packages/ros2/resources/convert__msg.cpp.em
+++ b/packages/ros2/resources/convert__msg.cpp.em
@@ -52,10 +52,17 @@ public:
   {
     _message = initialize();
 
+#ifndef RCLCPP__QOS_HPP_
     _subscription = node.create_subscription<Ros2_Msg>(
           topic_name,
           [=](Ros2_Msg::UniquePtr msg) { this->subscription_callback(*msg); },
           qos_profile);
+#else
+    _subscription = node.create_subscription<Ros2_Msg>(
+          topic_name,
+          rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
+          [=](Ros2_Msg::UniquePtr msg) { this->subscription_callback(*msg); });
+#endif
   }
 
 private:
@@ -104,7 +111,15 @@ public:
       const std::string& topic_name,
       const rmw_qos_profile_t& qos_profile)
   {
+#ifndef RCLCPP__QOS_HPP_
+    // If the rclcpp/qos.hpp header does not exist, then we assume that we
+    // are in crystal
     _publisher = node.create_publisher<Ros2_Msg>(topic_name, qos_profile);
+#else
+    _publisher = node.create_publisher<Ros2_Msg>(
+          topic_name,
+          rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)));
+#endif
   }
 
   bool publish(const soss::Message& message) override

--- a/packages/rosidl/scripts/soss_rosidl_find_package_info.py
+++ b/packages/rosidl/scripts/soss_rosidl_find_package_info.py
@@ -6,10 +6,10 @@ import os
 import sys
 
 try:
-    from rosidl_parser import parse_message_file
-    from rosidl_parser import parse_service_file
+    from rosidl_adapter.parser import parse_message_file
+    from rosidl_adapter.parser import parse_service_file
 except ImportError:
-    print('Unable to import rosidl_parser. Please source a ROS2 installation first.', end='', file=sys.stderr)
+    print('Unable to import rosidl_adapter. Please source a ROS2 installation first.', end='', file=sys.stderr)
     sys.exit(1)
 
 from ament_index_python.packages import get_package_share_directory

--- a/packages/rosidl/scripts/soss_rosidl_generate.py
+++ b/packages/rosidl/scripts/soss_rosidl_generate.py
@@ -9,11 +9,11 @@ import os
 import sys
 
 try:
-    from rosidl_parser import parse_message_file
-    from rosidl_parser import parse_service_file
+    from rosidl_adapter.parser import parse_message_file
+    from rosidl_adapter.parser import parse_service_file
     from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 except ImportError:
-    print('Unable to import rosidl_parser. Please source a ROS2 installation first.', end='', file=sys.stderr)
+    print('Unable to import rosidl_adapter. Please source a ROS2 installation first.', end='', file=sys.stderr)
     sys.exit(1)
 
 


### PR DESCRIPTION
These minor changes allow soss to be opaquely compiled against either Crystal or Dashing releases of ROS2.

The changes in the C++ files were not strictly necessary, but they reduced a considerable flood of deprecation warnings during build time.