### PR TITLE
Add middleware configurations parameters for each topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,5 +182,6 @@ systems:
 	mw2: {...}
 {...}
 topics:
-	topic_name: { type: topic_type, route: mw1_to_mw2, mw1 : {mw1_params}, mw2 : {mw2_params } }
+	topic_name: { type: topic_type, route: mw1_to_mw2, mw1 : { mw1_params }, mw2 : { mw2_params } }
 ```
+

--- a/README.md
+++ b/README.md
@@ -171,3 +171,14 @@ $ rostopic pub -r 1 /hello_ros2 std_msgs/String "Hello, ros2"
 
 Unfortunately this demo requires 6 shell environments to run, but soss itself only occupies
 one shell.
+
+### Configuring the topic's middleware
+
+It is possible to customize the behavior of the middlewares for each topic by adding a map with the system name as a key and the desired parameters as value, for example:
+
+`systems:
+	mw1: {...}
+	mw2: {...}
+{...}
+topics:
+	topic_name: { type: topic_type, route: mw1_to_mw2, mw1 : {mw1_params}, mw2 : {mw2_params } }`

--- a/README.md
+++ b/README.md
@@ -176,9 +176,11 @@ one shell.
 
 It is possible to customize the behavior of the middlewares for each topic by adding a map with the system name as a key and the desired parameters as value, for example:
 
-`systems:
+```
+systems:
 	mw1: {...}
 	mw2: {...}
 {...}
 topics:
-	topic_name: { type: topic_type, route: mw1_to_mw2, mw1 : {mw1_params}, mw2 : {mw2_params } }`
+	topic_name: { type: topic_type, route: mw1_to_mw2, mw1 : {mw1_params}, mw2 : {mw2_params } }
+```

--- a/packages/core/src/Config.cpp
+++ b/packages/core/src/Config.cpp
@@ -252,9 +252,14 @@ bool add_topic_or_service_config(
     }
   }
 
-  // TODO(MXG): Come up with a yaml scene for specifying middleware
-  // configurations per topic/service and then fill in the middleware_configs
-  // map here
+  for (const auto& mw : config.route.all())
+  {
+    const YAML::Node& mw_config = node[mw];
+    if (mw_config)
+    {
+      config.middleware_configs[mw] = mw_config;
+    }
+  }
 
   if(valid)
   {


### PR DESCRIPTION
This PR adds support for middleware specific configuration to be sent to downstream soss-xxx implementations.
They can be sent by adding a key value pair in the config file which has the middleware name as a key and the parameters as value.