### PR TITLE
Fixing foxy

### DIFF
--- a/packages/core/src/MiddlewareInterfaceExtension.cpp
+++ b/packages/core/src/MiddlewareInterfaceExtension.cpp
@@ -25,6 +25,7 @@
 #include <Windows.h>
 #include <assert.h>
 #else
+#include <cassert>
 #include <dlfcn.h>
 #endif
 


### PR DESCRIPTION
I was trying to follow to SOSS Build Example on a Ubunto 20.04 machine, with ros2 foxy. While building the packages with colcon i got an error caused by a missing include. After adding the missing include of <cassert> the colcon build still had an error about a missing dependence: Could NOT find FastRTPS (missing: FastRTPS_INCLUDE_DIR FastRTPS_LIBRARIES)
I was able to fix this error by setting the include-paths for fastRTPS directly inside the CMakeLists.txt.
After both those changes I was able to build SOSS successfully.  To test if it also works i was trying to further follow the build Example. As i am on a Ubunto 20.04 i was using ros1 neotic instead of melotic. I was not able to build the soss-ros1 plugin while using noetic and won't do any further testing why that is the case. Instead I am going to test the ros2_domain_change example to confirm that after successfully building soss can run on ros2 foxy. Launching the sample_ros2_domain_change.yaml file did work, but i have not yet created a listener node "soss_10" to test the wanted functionality.