### PR TITLE
Initialize output of soss::json::to_json with empty object

### DIFF
--- a/packages/json/src/conversion.cpp
+++ b/packages/json/src/conversion.cpp
@@ -303,7 +303,7 @@ struct Converter
 
   static Json to_json(const Message& input)
   {
-    Json output;
+    Json output({});
     convert_from_soss_message(input, output);
 
     return output;


### PR DESCRIPTION
This returns `{}` instead of `null` for empty (no fields) messages, e.g. [std_srvs/Trigger](http://docs.ros.org/en/api/std_srvs/html/srv/Trigger.html) requests.