### PR TITLE
ROS2 concurrency options

### DIFF
--- a/packages/ros2/resources/convert__srv.cpp.em
+++ b/packages/ros2/resources/convert__srv.cpp.em
@@ -168,13 +168,14 @@ public:
   {
     _request = initialize_request();
 
+    _callback_group = node.create_callback_group(rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
     _service = node.create_service<Ros2_Srv>(
           service_name,
           [=](const std::shared_ptr<rmw_request_id_t> request_header,
               const std::shared_ptr<Ros2_Request> request,
               const std::shared_ptr<Ros2_Response> response)
               { this->service_callback(request_header, request, response); },
-          qos_profile);
+          qos_profile, _callback_group);
   }
 
   void receive_response(
@@ -217,6 +218,7 @@ private:
   const std::shared_ptr<PromiseHolder> _handle;
   soss::Message _request;
   Ros2_Response _response;
+  rclcpp::callback_group::CallbackGroup::SharedPtr 	_callback_group;
   rclcpp::Service<Ros2_Srv>::SharedPtr _service;
 
 };

--- a/packages/ros2/src/SystemHandle.cpp
+++ b/packages/ros2/src/SystemHandle.cpp
@@ -24,6 +24,7 @@
 #include <soss/Search.hpp>
 
 #include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/executors/multi_threaded_executor.hpp>
 
 namespace soss {
 namespace ros2 {
@@ -147,8 +148,15 @@ bool SystemHandle::configure(
     _node = std::make_shared<rclcpp::Node>(name, ns);
   }
 
-  // TODO(MXG): Allow the type of executor to be specified by the configuration
-  _executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  if(const YAML::Node threads = configuration["threads"])
+  {
+    _executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(ExecutorOptions(), threads.as<size_t>(0));
+  }
+  else
+  {
+    _executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  }
+
   _executor->add_node(_node);
   _spinner = std::thread(std::bind(&Executor::spin, _executor));
 

--- a/packages/ros2/src/SystemHandle.hpp
+++ b/packages/ros2/src/SystemHandle.hpp
@@ -82,10 +82,12 @@ private:
 
   std::shared_ptr<rclcpp::Node> _node;
 #ifdef SOSS_ROS2__ROSIDL_GENERATOR_CPP
-  std::unique_ptr<rclcpp::executor::Executor> _executor;
+  using Executor=rclcpp::executor::Executor;
 #else
-  std::unique_ptr<rclcpp::Executor> _executor;
+  using Executor=rclcpp::Executor;
 #endif // SOSS_ROS2_ROSIDL_GENERATOR_CPP
+  std::shared_ptr<Executor> _executor;
+  std::thread _spinner;
 
   std::vector<std::shared_ptr<void>> _subscriptions;
   std::vector<std::shared_ptr<ServiceClient>> _client_proxies;

--- a/packages/ros2/src/SystemHandle.hpp
+++ b/packages/ros2/src/SystemHandle.hpp
@@ -23,8 +23,6 @@
 
 #include <soss/ros2/Factory.hpp>
 
-#include <rclcpp/executors/single_threaded_executor.hpp>
-
 #include <vector>
 
 namespace soss {
@@ -83,8 +81,10 @@ private:
   std::shared_ptr<rclcpp::Node> _node;
 #ifdef SOSS_ROS2__ROSIDL_GENERATOR_CPP
   using Executor=rclcpp::executor::Executor;
+  using ExecutorOptions=rclcpp::executor::ExecutorArgs;
 #else
   using Executor=rclcpp::Executor;
+  using ExecutorOptions=rclcpp::ExecutorOptions;
 #endif // SOSS_ROS2_ROSIDL_GENERATOR_CPP
   std::shared_ptr<Executor> _executor;
   std::thread _spinner;


### PR DESCRIPTION
This PR should improve the concurrent operation for ROS2.

With `SingleThreadedExecutor` (no `threads` config), `ClientProxy::service_callback` might block `spin_once`.
(E.g., if the remote service calls a local service or waits for a message, which leads to a deadlock)

In order to use `MultiThreadedExecutor`, each `ClientProxy` now has its own callback group and the executor is run in the background.


