### PR TITLE
Configure ROS_DOMAIN_ID per context

### DIFF
--- a/packages/ros2/src/SystemHandle.cpp
+++ b/packages/ros2/src/SystemHandle.cpp
@@ -199,7 +199,9 @@ bool SystemHandle::configure(
     }
 
     // TODO(MXG): Allow the type of executor to be specified by the configuration
-    _executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+    rclcpp::ExecutorOptions executor_options;
+    executor_options.context = _context;
+    _executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>(executor_options);
 
     auto register_type = [&](const std::string& type_name) -> bool
             {
@@ -273,7 +275,7 @@ bool SystemHandle::okay() const
 {
     if (_node)
     {
-        return rclcpp::ok();
+        return rclcpp::ok(_context);
     }
 
     return false;
@@ -283,7 +285,7 @@ bool SystemHandle::okay() const
 bool SystemHandle::spin_once()
 {
     _executor->spin_node_once(_node, std::chrono::milliseconds(100));
-    return rclcpp::ok();
+    return rclcpp::ok(_context);
 }
 
 //==============================================================================
@@ -292,7 +294,7 @@ SystemHandle::~SystemHandle()
     _subscriptions.clear();
     _client_proxies.clear();
 
-    rclcpp::shutdown();
+    rclcpp::shutdown(_context);
 }
 
 //==============================================================================

--- a/packages/ros2/src/SystemHandle.cpp
+++ b/packages/ros2/src/SystemHandle.cpp
@@ -171,6 +171,8 @@ bool SystemHandle::configure(
         _context = std::make_shared<rclcpp::Context>();
         _context->init(1, context_argv, init_options);
 
+        _executor_options.context = _context;
+
         _node_options = std::make_shared<rclcpp::NodeOptions>();
         _node_options->context(_context);
 
@@ -199,9 +201,7 @@ bool SystemHandle::configure(
     }
 
     // TODO(MXG): Allow the type of executor to be specified by the configuration
-    rclcpp::ExecutorOptions executor_options;
-    executor_options.context = _context;
-    _executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>(executor_options);
+    _executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>(_executor_options);
 
     auto register_type = [&](const std::string& type_name) -> bool
             {

--- a/packages/ros2/src/SystemHandle.hpp
+++ b/packages/ros2/src/SystemHandle.hpp
@@ -111,6 +111,8 @@ private:
     std::unique_ptr<rclcpp::Executor> _executor;
 #endif // SOSS_ROS2_ROSIDL_GENERATOR_CPP
 
+    rclcpp::ExecutorOptions _executor_options;
+
     std::vector<std::shared_ptr<void> > _subscriptions;
     std::vector<std::shared_ptr<ServiceClient> > _client_proxies;
 };


### PR DESCRIPTION
Fixes #50

Configuring the domain ID per node is no longer supported since ROS 2
changed the mapping of nodes to RMW participants from one-to-one to
many-to-one. You can check out the design document for more info:

http://design.ros2.org/articles/Node_to_Participant_mapping.html

This change fixes domain change functionality by mapping each ROS 2
node to it's own context and ensuring that the domain ID environment
variable is set before initializing the context.

Signed-off-by: Jacob Perron <jacob@openrobotics.org>
(cherry picked from commit 043f3303102ad7e4d7ff5cc3a0108d0c6fa80090)