### PR TITLE
Create request and subscription callback pools for correct destruction order

### DIFF
--- a/packages/core/include/is/core/Config.hpp
+++ b/packages/core/include/is/core/Config.hpp
@@ -160,6 +160,20 @@ class Config
 public:
 
     /**
+     * @brief Signature for the container used to store the subscription callbacks for a certain
+     *        *Integration Service* instance.
+     */
+    using SubscriptionCallbacks =
+            std::vector<std::unique_ptr<is::TopicSubscriberSystem::SubscriptionCallback> >;
+
+    /**
+     * @brief Signature for the container used to store the service request callbacks for a certain
+     *        *Integration Service* instance.
+     */
+    using RequestCallbacks =
+            std::vector<std::unique_ptr<is::ServiceClientSystem::RequestCallback> >;
+
+    /**
      * @brief Constructor.
      *
      * @param[in] node Parsed representation of the `YAML` configuration file.
@@ -316,10 +330,14 @@ public:
      *            the information for each loaded SystemHandle, in terms of its instance,
      *            supported types and publish/subscribe or client/server capabilities.
      *
+     * @param[in] subscription_callbacks Reference to the map used to store all of the active
+     *            subscription callbacks for a certain SystemHandle instance.
+     *
      * @returns `true` if all the topics were successfully configured, `false` otherwise.
      */
     bool configure_topics(
-            const is::internal::SystemHandleInfoMap& info_map) const;
+            const is::internal::SystemHandleInfoMap& info_map,
+            SubscriptionCallbacks& subscription_callbacks) const;
 
     /**
      * @brief Configures services, according to the specified route, type and remapping
@@ -352,10 +370,14 @@ public:
      *            the information for each loaded SystemHandle, in terms of its instance,
      *            supported types and publish/subscribe and client/server capabilities.
      *
+     * @param[in] request_callbacks Reference to the map used to store all of the active
+     *            request callbacks for a certain SystemHandle instance.
+     *
      * @returns `true` if all the services were successfully configured, `false` otherwise.
      */
     bool configure_services(
-            const is::internal::SystemHandleInfoMap& info_map) const;
+            const is::internal::SystemHandleInfoMap& info_map,
+            RequestCallbacks& request_callbacks) const;
 
     /**
      * @brief Checks compatibility between the TopicInfo registered in the endpoints responsible

--- a/packages/core/include/is/systemhandle/SystemHandle.hpp
+++ b/packages/core/include/is/systemhandle/SystemHandle.hpp
@@ -212,7 +212,7 @@ public:
     virtual bool subscribe(
             const std::string& topic_name,
             const xtypes::DynamicType& message_type,
-            SubscriptionCallback callback,
+            SubscriptionCallback* callback,
             const YAML::Node& configuration) = 0;
 };
 
@@ -417,7 +417,7 @@ public:
     virtual bool create_client_proxy(
             const std::string& service_name,
             const xtypes::DynamicType& service_type,
-            RequestCallback callback,
+            RequestCallback* callback,
             const YAML::Node& configuration)
     {
         (void)service_name, (void)service_type, (void)callback, (void)configuration;
@@ -446,7 +446,7 @@ public:
             const std::string& service_name,
             const xtypes::DynamicType& request_type,
             const xtypes::DynamicType& reply_type,
-            RequestCallback callback,
+            RequestCallback* callback,
             const YAML::Node& configuration)
     {
         (void)reply_type;

--- a/packages/core/src/Instance.cpp
+++ b/packages/core/src/Instance.cpp
@@ -99,14 +99,14 @@ public:
             return false;
         }
 
-        if (!_configuration.configure_topics(_info_map))
+        if (!_configuration.configure_topics(_info_map, subscription_callbacks_))
         {
             _logger << utils::Logger::Level::ERROR
                     << "Failed to configure topics!" << std::endl;
             return false;
         }
 
-        if (!_configuration.configure_services(_info_map))
+        if (!_configuration.configure_services(_info_map, request_callbacks_))
         {
             _logger << utils::Logger::Level::ERROR
                     << "Failed to configure services!" << std::endl;
@@ -266,6 +266,10 @@ private:
     internal::Config _configuration;
 
     is::internal::SystemHandleInfoMap _info_map;
+
+    internal::Config::SubscriptionCallbacks subscription_callbacks_;
+
+    internal::Config::RequestCallbacks request_callbacks_;
 
     std::atomic_bool _quit;
 

--- a/packages/mock/src/SystemHandle.cpp
+++ b/packages/mock/src/SystemHandle.cpp
@@ -52,7 +52,7 @@ public:
     Channels clients;
     Channels services;
 
-    std::map <std::string, TopicSubscriberSystem::SubscriptionCallback*> is_subscription_callbacks;
+    std::map<std::string, TopicSubscriberSystem::SubscriptionCallback*> is_subscription_callbacks;
 
     std::map<std::string, ServiceClientSystem::RequestCallback*> is_request_callbacks;
 


### PR DESCRIPTION
If callbacks are not all destroyed at once, then crossed references to respective SystemHandle's TopicPublisher ServiceClientSystem entities will be kept, and a systemhandle might be destructed before its topicPublisher, leading to corruption errors. This PR should fix this.
Before merge, please review and check that the following PRs are passing its CI:
* https://github.com/eProsima/WebSocket-SH/pull/6
* https://github.com/eProsima/ROS2-SH/pull/3
* https://github.com/eProsima/ROS1-SH/pull/15

Signed-off-by: Jose Antonio Moral <joseantoniomoralparras@gmail.com>