### PR TITLE
Detected a topic mismatch on DDS->ROS2 example

### DIFF
--- a/examples/basic/fastdds_ros2__helloworld.yaml
+++ b/examples/basic/fastdds_ros2__helloworld.yaml
@@ -28,6 +28,6 @@ topics:
         route: dds_to_ros2,
         remap: {
             dds: { type: HelloWorld, topic: HelloWorldTopic },
-            ros2: { topic: "listener" }
+            ros2: { topic: "chatter" }
         }
     }


### PR DESCRIPTION
Note besides that in order to generate the *mix* file associated with `std_msgs/String` type is mandatory to build the tests.
Building only the examples they cannot be run unless the package `is-ros2-mix-generator` is explicitly built.