### PR TITLE
Use galactic docker for CI now that it is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   integration-service_CI:
     strategy:
       matrix:
-        node: [foxy, rolling]
+        node: [foxy, galactic]
     runs-on: ubuntu-20.04
     container: ros:${{ matrix.node }}
 


### PR DESCRIPTION
Signed-off-by: Jose Antonio Moral <joseantoniomoralparras@gmail.com>