### PR TITLE
Fixes the error produced when a YAML try to inherit from several systems using the types-from tag

### DIFF
--- a/core/src/Config.cpp
+++ b/core/src/Config.cpp
@@ -819,7 +819,7 @@ bool Config::parse(
         {
             if (types_from_node.IsSequence())
             {
-                for (const YAML::Node& types : types_from_node)
+                for (const YAML::Node types : types_from_node)
                 {
                     types_from.push_back(types.as<std::string>());
                 }


### PR DESCRIPTION
- This error is produced due to how libyaml-cpp implements the const dereference operator, which returns a copy of the Node instead of a reference