### PR TITLE
Add IS_THIRDPARTY flag to init the xtypes submodule [12212]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,105 @@ jobs:
           curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC1CF6E31E6BADE8868B172B4F42ED6FBAB17C654' | sudo apt-key add -
           apt update && apt install -y ros-noetic-ros-base
 
+      - name: Download xTypes
+        run: |
+          git clone --recursive https://github.com/eProsima/xtypes.git src/xtypes
+
+      - name: Download the Integration Service Fast DDS SystemHandle
+        run: |
+          git clone https://github.com/eProsima/FastDDS-SH.git src/fastdds-sh
+
+      - name: Download the Integration Service ROS 1 SystemHandle
+        run: |
+          git clone https://github.com/eProsima/ROS1-SH.git src/ros1-sh
+
+      - name: Download the Integration Service ROS 2 SystemHandle
+        run: |
+          git clone https://github.com/eProsima/ROS2-SH.git src/ros2-sh
+
+      - name: Download the Integration Service WebSocket SystemHandle
+        run: |
+          git clone https://github.com/eProsima/WebSocket-SH.git src/websocket-sh
+
+      - name: Download the Integration Service FIWARE SystemHandle
+        run: |
+          git clone https://github.com/eProsima/FIWARE-SH.git src/fiware-sh
+
+      - name: Install ROS 1 example_interfaces package
+        working-directory: ./src/integration-service/examples/utils/ros1/catkin_ws
+        run: |
+          . /opt/ros/noetic/setup.sh
+          catkin_make -DBUILD_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic install
+
+      - name: Build
+        run: |
+          . /opt/ros/${{ matrix.node }}/setup.sh
+          colcon build --packages-skip-regex is-ros1 --cmake-args -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_TESTS=ON -DIS_ROS2_DISTRO=${{ matrix.node }} --event-handlers console_direct+
+          . /opt/ros/noetic/setup.sh
+          colcon build --cmake-args -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DIS_ROS2_DISTRO=${{ matrix.node }} --event-handlers console_direct+
+
+      - name: Test the Integration Service Core
+        run: |
+          colcon test --packages-select is-core --event-handlers console_direct+
+          colcon test-result
+
+      - name: Test the Integration Service Fast DDS SystemHandle
+        run: |
+          . /opt/ros/${{ matrix.node }}/setup.sh
+          colcon test --packages-select is-fastdds --event-handlers console_direct+
+          colcon test-result
+
+      - name: Test the Integration Service ROS 1 SystemHandle
+        run: |
+          . /opt/ros/noetic/setup.sh
+          roscore &
+          echo "Waiting until roscore has been launched..."
+          sleep 5
+          . install/local_setup.sh
+          colcon test --packages-select is-ros1 --event-handlers console_direct+
+          colcon test-result
+
+      - name: Test the Integration Service ROS 2 SystemHandle
+        run: |
+          . /opt/ros/${{ matrix.node }}/setup.sh
+          . install/setup.sh
+          RMW_IMPLEMENTATION=rmw_fastrtps_cpp colcon test --packages-select is-ros2 --event-handlers console_direct+
+          colcon test-result
+
+      - name: Test the Integration Service WebSocket SystemHandle
+        run: |
+          colcon test --packages-select is-websocket --event-handlers console_direct+
+          colcon test-result
+
+      #- name: Test the Integration Service FIWARE SystemHandle
+      #  run: |
+      #    colcon test --packages-select is-fiware --event-handlers console_direct+
+      #    colcon test-result
+      
+  integration-service_submodule_CI:
+    strategy:
+      matrix:
+        node: [foxy, galactic]
+    runs-on: ubuntu-20.04
+    container: ros:${{ matrix.node }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/integration-service
+
+      - name: Download required dependencies
+        run: |
+          apt update
+          DEBIAN_FRONTEND=noninteractive apt install -y curl git libboost-dev libboost-program-options-dev libyaml-cpp-dev libwebsocketpp-dev libssl-dev libcurlpp-dev libasio-dev libcurl4-openssl-dev ros-${{ matrix.node }}-fastrtps ros-${{ matrix.node }}-rmw-fastrtps-cpp
+
+      - name: Download and install ROS 1 Noetic
+        run: |
+          echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
+          apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+          curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC1CF6E31E6BADE8868B172B4F42ED6FBAB17C654' | sudo apt-key add -
+          apt update && apt install -y ros-noetic-ros-base
+
       - name: Download the Integration Service Fast DDS SystemHandle
         run: |
           git clone https://github.com/eProsima/FastDDS-SH.git src/fastdds-sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
           curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC1CF6E31E6BADE8868B172B4F42ED6FBAB17C654' | sudo apt-key add -
           apt update && apt install -y ros-noetic-ros-base
 
-      - name: Download xTypes
-        run: |
-          git clone --recursive https://github.com/eProsima/xtypes.git src/xtypes
-
       - name: Download the Integration Service Fast DDS SystemHandle
         run: |
           git clone https://github.com/eProsima/FastDDS-SH.git src/fastdds-sh

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 ###############################################################################
 if(BUILD_LIBRARY)
 
-  if(IS_THIRDPARTY)
+  find_package(xtypes QUIET)
+  if(IS_THIRDPARTY AND NOT xtypes_FOUND)
     message(STATUS "Updating submodules")
     execute_process(
       COMMAND git submodule update --init
@@ -88,8 +89,8 @@ if(BUILD_LIBRARY)
           PATTERN "*.hpp"
       )
     endif()
-  else()
-    find_package(xtypes REQUIRED)
+  elseif(NOT IS_THIRDPARTY AND NOT xtypes_FOUND)
+      message(FATAL_ERROR "xtypes not found")
   endif()
 
   find_package(yaml-cpp REQUIRED)
@@ -173,6 +174,7 @@ if(BUILD_LIBRARY)
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../thirdparty/xtypes/include>
+      $<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/../xtypes/thirdparty/cpp-peglib/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
       #$<INSTALL_INTERFACE:${xtypes_INCLUDE_DIR}>  #propagate the xtypes headers
   )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -78,6 +78,15 @@ if(BUILD_LIBRARY)
         FILES_MATCHING
           PATTERN "*.hpp"
       )
+      
+      file(
+        COPY
+          ${PROJECT_SOURCE_DIR}/../thirdparty/xtypes/thirdparty/cpp-peglib
+        DESTINATION
+          ${CMAKE_INSTALL_PREFIX}/include
+        FILES_MATCHING
+          PATTERN "*.hpp"
+      )
     endif()
   else()
     find_package(xtypes REQUIRED)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,6 +27,7 @@ cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 option(IS_COMPILE_DEBUG "Compile the Integration Service project in debug mode." OFF)
 
 option(BUILD_LIBRARY "Compile the Integration Service" ON)
+option(IS_THIRDPARTY "Allow to download thidparty repository when needed." ON)
 
 if(DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE_LOWERCASE "" CACHE STRING "Build type to lowercase")
@@ -57,6 +58,22 @@ endif()
 # External dependencies for the Integration Service Core library
 ###############################################################################
 if(BUILD_LIBRARY)
+
+  if(IS_THIRDPARTY)
+    message(STATUS "Updating submodules")
+    execute_process(
+      COMMAND git submodule update --init
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/../
+      RESULT_VARIABLE EXECUTE_RESULT
+    )
+
+    if(NOT EXECUTE_RESULT EQUAL 0)
+      message(ERROR "Cannot update git submodules")
+    else()
+      set(CMAKE_PREFIX_PATH ${PROJECT_SOURCE_DIR}/thirdparty/xtypes ${CMAKE_PREFIX_PATH})
+    endif()
+  endif()
+
   find_package(xtypes REQUIRED)
 
   find_package(yaml-cpp REQUIRED)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -70,11 +70,18 @@ if(BUILD_LIBRARY)
     if(NOT EXECUTE_RESULT EQUAL 0)
       message(ERROR "Cannot update git submodules")
     else()
-      set(CMAKE_PREFIX_PATH ${PROJECT_SOURCE_DIR}/thirdparty/xtypes ${CMAKE_PREFIX_PATH})
+      file(
+        COPY
+          ${PROJECT_SOURCE_DIR}/../thirdparty/xtypes/include/xtypes
+        DESTINATION
+          ${CMAKE_INSTALL_PREFIX}/include
+        FILES_MATCHING
+          PATTERN "*.hpp"
+      )
     endif()
+  else()
+    find_package(xtypes REQUIRED)
   endif()
-
-  find_package(xtypes REQUIRED)
 
   find_package(yaml-cpp REQUIRED)
 
@@ -156,6 +163,7 @@ if(BUILD_LIBRARY)
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../thirdparty/xtypes/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
       #$<INSTALL_INTERFACE:${xtypes_INCLUDE_DIR}>  #propagate the xtypes headers
   )


### PR DESCRIPTION
- [ ] Update the documentation to add the new flag
- [ ] Add new CI to check both options?

NOTE: It works when xTypes is used as external repository and when Integration Service is cloned using the `--recursive` option, but it is still not working when Integration Service is cloned without initializing the submodule.