### PR TITLE
Remove explicitly defaulted move constructor

### DIFF
--- a/core/src/runtime/MiddlewareInterfaceExtension.cpp
+++ b/core/src/runtime/MiddlewareInterfaceExtension.cpp
@@ -62,12 +62,6 @@ public:
         assert(std::experimental::filesystem::is_directory(_directory));
     }
 
-    Implementation(
-            const Implementation& /*other*/) = default;
-
-    Implementation(
-            Implementation&& /*other*/) = default;
-
     ~Implementation() = default;
 
     bool load()

--- a/core/src/runtime/MiddlewareInterfaceExtension.cpp
+++ b/core/src/runtime/MiddlewareInterfaceExtension.cpp
@@ -62,8 +62,6 @@ public:
         assert(std::experimental::filesystem::is_directory(_directory));
     }
 
-    ~Implementation() = default;
-
     bool load()
     {
         bool result = true;


### PR DESCRIPTION
Partially completes #192

This patch resolves: "warning: explicitly defaulted move constructor is implicitly deleted [-Wdefaulted-function-deleted]"