### PR TITLE
Fix reference to local binding in lambda capture

### DIFF
--- a/core/src/Config.cpp
+++ b/core/src/Config.cpp
@@ -1088,6 +1088,7 @@ bool Config::load_middlewares(
      */
     for (const auto& [mw_name, mw_config] : middlewares)
     {
+        const auto& ref_mw_name = mw_name;
         const std::string& middleware_type = mw_config.type;
 
         logger << utils::Logger::Level::DEBUG
@@ -1250,10 +1251,10 @@ bool Config::load_middlewares(
             // Check if another middleware relies on types builtin or dynamically loaded by the middleware but not
             // explicit in the configuration file
             if ( middlewares.end() ==
-                    std::find_if(middlewares.begin(), middlewares.end(), [&mw_name](const Entry& mw)
+                    std::find_if(middlewares.begin(), middlewares.end(), [&ref_mw_name](const Entry& mw)
                     {
                         auto& from = mw.second.types_from;
-                        return mw_name != mw.first && std::find(from.begin(), from.end(), mw_name) != from.end();
+                        return ref_mw_name != mw.first && std::find(from.begin(), from.end(), ref_mw_name) != from.end();
                     }))
             {
                 logger << utils::Logger::Level::ERROR

--- a/core/src/Instance.cpp
+++ b/core/src/Instance.cpp
@@ -159,13 +159,15 @@ public:
              * For each systemhandle, creates a working thread that will check that the
              * SystemHandle instance is alive and calls spin_once() to execute pending work.
              */
+            const auto& ref_mw_name = mw_name;
+            const auto& ref_systemhandle_info = systemhandle_info;
             auto runner = [&]()
                     {
                         ++_active_middlewares;
 
                         while (!interrupted && !_quit)
                         {
-                            const bool okay = systemhandle_info.handle->spin_once();
+                            const bool okay = ref_systemhandle_info.handle->spin_once();
 
                             if (!okay)
                             {
@@ -173,7 +175,7 @@ public:
                                 _return_code = 1;
                                 _logger << utils::Logger::Level::ERROR
                                         << "Runtime Error: SystemHandle of middleware named '"
-                                        << mw_name
+                                        << ref_mw_name
                                         << "' has experienced a failure! We will now quit."
                                         << std::endl;
                             }


### PR DESCRIPTION
Partially completes #192

`clang` reports the attempt to capture the variable declared in the structured binding as an error. 

See:
- https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding